### PR TITLE
Make sure country can still be looked up on the Supporter record

### DIFF
--- a/models.py
+++ b/models.py
@@ -519,6 +519,14 @@ class Supporter(models.Model):
         return self.band.size if self.band else None
 
     @property
+    def country(self):
+        return self.band.country if self.band else None
+
+    @property
+    def country_name(self):
+        return self.band.country.name if self.band and self.band.country else ''
+
+    @property
     def level(self):
         return self.band.level if self.band else None
 

--- a/views.py
+++ b/views.py
@@ -153,6 +153,7 @@ def supporters(request):
     supporters = supporter_models.Supporter.objects.filter(
         active=True,
         display=True,
+        band__isnull=False,
     ).order_by(
         'band__country', 'name'
     )


### PR DESCRIPTION
This preserves the `Supporter.country` interface by adding a method where the field used to be. The field was removed in favor of the `Band.country` field, which is where country usually needs to be accessed for calculating fees and things.

With this fix, not so much is required to change on the supporter list page on Hourglass to get it looking good. So this contributes to closing https://github.com/openlibhums/hourglass/issues/397.