### PR TITLE
Add confirmation step to Recommend Us page

### DIFF
--- a/plugin_settings.py
+++ b/plugin_settings.py
@@ -10,7 +10,7 @@ SHORT_NAME = 'consortial_billing'
 MANAGER_URL = 'supporters_manager'
 DESCRIPTION = 'This plugin helps presses manage consortial support'
 AUTHOR = 'Open Library of Humanities'
-VERSION = '2.3'
+VERSION = '2.3.1'
 JANEWAY_VERSION = "1.7"
 IS_WORKFLOW_PLUGIN = False
 

--- a/urls.py
+++ b/urls.py
@@ -78,4 +78,9 @@ urlpatterns = [
         views.recommend_us_generate_email,
         name='recommend_us_generate_email',
     ),
+    re_path(
+        r'^recommend-us/confirm-sent/$',
+        views.recommend_us_confirm_sent,
+        name='recommend_us_confirm_sent',
+    ),
 ]

--- a/views.py
+++ b/views.py
@@ -598,3 +598,17 @@ def recommend_us_generate_email(request):
 
     template = requires_hourglass('custom/recommend-us-generate-email.html')
     return render(request, template, context)
+
+
+@require_POST
+def recommend_us_confirm_sent(request):
+    template = requires_hourglass('custom/recommend-us-confirm-sent.html')
+    previous_step = request.POST.get('previous_step', '6')
+    try:
+        step = str(int(previous_step) + 1)
+    except ValueError:
+        step = '7'
+    context = {
+        'step': step,
+    }
+    return render(request, template, context)


### PR DESCRIPTION
Goes with https://github.com/openlibhums/hourglass/pull/404.

Closes openlibhums/hourglass#405.

I also just noticed this PR includes a commit I meant to put on main before tagging v2.3.1, dec183fa83a5706a8a7f648c4db079568499acbd. Annoying but maybe not a problem?