### PR TITLE
Use plain text in Recommend Us emails

### DIFF
--- a/install/settings.json
+++ b/install/settings.json
@@ -158,10 +158,10 @@
       "is_translatable": true,
       "name": "recommend_us_general_email",
       "pretty_name": "Recommend Us General Email",
-      "type": "rich-text"
+      "type": "text"
     },
     "value": {
-      "default": "<p>Dear Librarian,</p><p>I am writing to ask if the library would be able to join the Open Library of Humanities please? I am very impressed with their <a href=\"https://www.openlibhums.org/site/become-a-supporter/\">excellent cause as a diamond open-access publisher</a>. Many thanks.</p>"
+      "default": "Dear Librarian,\n\nI am writing to ask if the library would be able to join the Open Library of Humanities please? I am very impressed with their excellent cause as a diamond open-access publisher (see https://www.openlibhums.org/site/become-a-supporter/ ).\n\nMany thanks."
     }
   },
   {
@@ -173,10 +173,10 @@
       "is_translatable": true,
       "name": "recommend_us_author_email",
       "pretty_name": "Recommend Us Author Email",
-      "type": "rich-text"
+      "type": "text"
     },
     "value": {
-      "default": "<p>Dear Librarian,</p><p>I am writing to ask if the library would be able to join the Open Library of Humanities please? I recently published my paper ‘<a href=\"{% if article.doi %}{{ article.doi }}{% else %}{{ article.url }}{% endif %}\">{{ article.title|safe }}</a>’ in <i>{{ article.journal.name }}</i> with the Open Library of Humanities, and I was very impressed with their publication process and <a href=\"https://www.openlibhums.org/site/become-a-supporter/\">excellent cause as a diamond open-access publisher</a>. Many thanks.</p>"
+      "default": "Dear Librarian,\n\nI am writing to ask if the library would be able to join the Open Library of Humanities please? I recently published my paper ‘{{ article.title|safe }}’ ( {% if article.doi %}{{ article.doi }}{% else %}{{ article.url }}{% endif %} ) in {{ article.journal.name }} with the Open Library of Humanities. I was very impressed with their publication process and excellent cause as a diamond open-access publisher (see https://www.openlibhums.org/site/become-a-supporter/ ).\n\nMany thanks."
     }
   },
   {
@@ -188,10 +188,10 @@
       "is_translatable": true,
       "name": "recommend_us_reader_email",
       "pretty_name": "Recommend Us Reader Email",
-      "type": "rich-text"
+      "type": "text"
     },
     "value": {
-      "default": "<p>Dear Librarian,</p><p>I am writing to ask if the library would be able to join the Open Library of Humanities please? I recently read ‘<a href=\"{% if article.doi %}{{ article.doi }}{% else %}{{ article.url }}{% endif %}\">{{ article.title|safe }}</a>’ in <i>{{ article.journal.name }}</i>, and I was very impressed with their publication process and <a href=\"https://www.openlibhums.org/site/become-a-supporter/\">excellent cause as a diamond open-access publisher</a>. Many thanks.</p>"
+      "default": "Dear Librarian,\n\nI am writing to ask if the library would be able to join the Open Library of Humanities please? I recently read ‘{{ article.title|safe }}’ ( {% if article.doi %}{{ article.doi }}{% else %}{{ article.url }}{% endif %} ) in {{ article.journal.name }}. I was very impressed with their excellent cause as a diamond open-access publisher (see https://www.openlibhums.org/site/become-a-supporter/ ).\n\nMany thanks."
     }
   },
   {
@@ -203,10 +203,10 @@
       "is_translatable": true,
       "name": "recommend_us_editor_email",
       "pretty_name": "Recommend Us Editor Email",
-      "type": "rich-text"
+      "type": "text"
     },
     "value": {
-      "default": "<p>Dear Librarian,</p><p>I am writing to ask if the library would be able to join the Open Library of Humanities please? I am an editor for <a href=\"{{ journal.site_url }}\"><i>{{ journal.name }}</i></a>, and I am in strong support of their <a href=\"https://www.openlibhums.org/site/become-a-supporter/\">excellent cause as a diamond open-access publisher</a>. Many thanks.</p>"
+      "default": "Dear Librarian,\n\nI am writing to ask if the library would be able to join the Open Library of Humanities please? I am an editor for {{ journal.name }} ( {{ journal.site_url }} ), and I am in strong support of their excellent cause as a diamond open-access publisher (see https://www.openlibhums.org/site/become-a-supporter/ ).\n\nMany thanks."
     }
   }
 ]


### PR DESCRIPTION
Closes openlibhums/hourglass#406.

Depends on https://github.com/openlibhums/hourglass/pull/408.

NOTE: On deployment, please delete the four existing Recommend Us email setting values and reload them, so they get entered as plain text settings. I've checked the old rich-text versions (edited by Rose in openlibhums.org) and implemented her edits in the new plain-text defaults.